### PR TITLE
fix: fixed installation of dependencies

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
 
     "scripts": {
         "test:unit": "vitest",
+        "build": "run-p type-check \"build-only {@}\" --",
         "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
         "format": "prettier --write src/",
         "start-flask": "cd ../server && flask run",

--- a/client/package.json
+++ b/client/package.json
@@ -9,10 +9,16 @@
     "type": "module",
 
     "scripts": {
+        "dev": "vite",
+        "build": "run-p type-check \"build-only {@}\" --",
+        "preview": "vite preview",
         "test:unit": "vitest",
+        "build-only": "vite build",
+        "type-check": "vue-tsc --build --force",
         "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
         "format": "prettier --write src/",
-        "start-flask": "cd ../server && flask run",
+        "start-flask-with-reload": "cd .. && .venv\\Scripts\\activate && cd ./server && flask run --debug --extra-files ../server/",
+        "start-flask": "cd .. && .venv\\Scripts\\activate && cd ./server && flask run",
         "run-prod": "npm run build-only && start-flask",
         "start-vue": "npm run dev",
         "start": "npm-run-all --parallel start-flask start-vue"

--- a/run.py
+++ b/run.py
@@ -77,7 +77,7 @@ def install_software(current_os: str):
         )
     elif current_os == "WINDOWS":
         subprocess.run(
-            ["py -3.12", "-m", "venv", os.path.join("server", ".python-venv")]
+            ["py", "-3.12", "-m", "venv", os.path.join("server", ".python-venv")]
         )
     else:
         raise Exception("What OS are you using?")


### PR DESCRIPTION
- the original subprocess.run was considering py -3.12 as a single string which returns '"py -3.12"' making it an invalid shell command.